### PR TITLE
chore: added enable flag for all storage services

### DIFF
--- a/metrices/simulator.py
+++ b/metrices/simulator.py
@@ -101,14 +101,13 @@ class MainframeSimulator:
         """Store metric data to all enabled storage systems"""
         # Add to S3 batch buffer
         if self.s3_service:
-            if self.s3_service:
-                self.s3_batch_buffer.append(metric_data)
-                
-                # Check if we need to flush the batch
-                current_time = time.time()
-                if (len(self.s3_batch_buffer) >= self.s3_batch_size or 
-                    current_time - self.last_s3_flush > self.s3_flush_interval):
-                    self._flush_s3_batch()
+            self.s3_batch_buffer.append(metric_data)
+            
+            # Check if we need to flush the batch
+            current_time = time.time()
+            if (len(self.s3_batch_buffer) >= self.s3_batch_size or 
+                current_time - self.last_s3_flush > self.s3_flush_interval):
+                self._flush_s3_batch()
     
     def _flush_s3_batch(self):
         """Flush the S3 batch buffer"""


### PR DESCRIPTION
This pull request introduces configurable initialization for storage services in the `MainframeSimulator` class, allowing users to enable or disable MySQL, MongoDB, and S3 services. It also adds conditional checks to ensure that storage operations are only performed if the respective services are enabled. These changes improve flexibility and robustness by preventing unnecessary service initialization and handling service failures gracefully.

### Initialization Enhancements:
* Updated the `MainframeSimulator` constructor to accept `enable_mysql`, `enable_mongodb`, and `enable_s3` flags, and moved the initialization of storage services to a new `_initialize_storage_services` method. This method initializes each service conditionally and logs errors if initialization fails. (`metrices/simulator.py`, [[1]](diffhunk://#diff-54d453aaf189058c34344ce2f51ad7ece84662392bd4d6eb454ab4e414d63714L16-R32) [[2]](diffhunk://#diff-54d453aaf189058c34344ce2f51ad7ece84662392bd4d6eb454ab4e414d63714R51-R76)

### Conditional Storage Operations:
* Added conditional checks for `self.s3_service` before appending metrics to the S3 batch buffer. (`metrices/simulator.py`, [metrices/simulator.pyR103](diffhunk://#diff-54d453aaf189058c34344ce2f51ad7ece84662392bd4d6eb454ab4e414d63714R103))
* Added conditional checks for `self.db_service` and `self.mongo_service` before inserting metrics into MySQL and MongoDB, respectively, across multiple simulation methods (`simulate_cpu_metrics`, `simulate_memory_metrics`, `simulate_ldev_metrics`, `simulate_clpr_metrics`, `simulate_mpb_metrics`, `simulate_ports_metrics`, and `simulate_volumes_metrics`). (`metrices/simulator.py`, [[1]](diffhunk://#diff-54d453aaf189058c34344ce2f51ad7ece84662392bd4d6eb454ab4e414d63714R159) [[2]](diffhunk://#diff-54d453aaf189058c34344ce2f51ad7ece84662392bd4d6eb454ab4e414d63714R168) [[3]](diffhunk://#diff-54d453aaf189058c34344ce2f51ad7ece84662392bd4d6eb454ab4e414d63714R246) [[4]](diffhunk://#diff-54d453aaf189058c34344ce2f51ad7ece84662392bd4d6eb454ab4e414d63714R255) [[5]](diffhunk://#diff-54d453aaf189058c34344ce2f51ad7ece84662392bd4d6eb454ab4e414d63714R334) [[6]](diffhunk://#diff-54d453aaf189058c34344ce2f51ad7ece84662392bd4d6eb454ab4e414d63714R346) [[7]](diffhunk://#diff-54d453aaf189058c34344ce2f51ad7ece84662392bd4d6eb454ab4e414d63714R420) [[8]](diffhunk://#diff-54d453aaf189058c34344ce2f51ad7ece84662392bd4d6eb454ab4e414d63714R435) [[9]](diffhunk://#diff-54d453aaf189058c34344ce2f51ad7ece84662392bd4d6eb454ab4e414d63714R518) [[10]](diffhunk://#diff-54d453aaf189058c34344ce2f51ad7ece84662392bd4d6eb454ab4e414d63714R530) [[11]](diffhunk://#diff-54d453aaf189058c34344ce2f51ad7ece84662392bd4d6eb454ab4e414d63714R603) [[12]](diffhunk://#diff-54d453aaf189058c34344ce2f51ad7ece84662392bd4d6eb454ab4e414d63714R615) [[13]](diffhunk://#diff-54d453aaf189058c34344ce2f51ad7ece84662392bd4d6eb454ab4e414d63714R692) [[14]](diffhunk://#diff-54d453aaf189058c34344ce2f51ad7ece84662392bd4d6eb454ab4e414d63714R704)

### Default Configuration:
* Updated the simulator initialization in `update_all_metrics` to disable all storage services by default (`enable_mysql=False`, `enable_mongodb=False`, `enable_s3=False`). (`metrices/simulator.py`, [metrices/simulator.pyL715-R764](diffhunk://#diff-54d453aaf189058c34344ce2f51ad7ece84662392bd4d6eb454ab4e414d63714L715-R764))